### PR TITLE
Relation branch

### DIFF
--- a/kb_main/agents/agents_operations_on_relations/agent_checking_whether_the_agent_is_a_transitive_relation/agent_checking_whether_the_agent_is_a_transitive_relation.scsi
+++ b/kb_main/agents/agents_operations_on_relations/agent_checking_whether_the_agent_is_a_transitive_relation/agent_checking_whether_the_agent_is_a_transitive_relation.scsi
@@ -1,401 +1,304 @@
 agent_checking_whether_the_agent_is_a_transitive_relation
 => nrel_main_idtf:
-	[агентная scp-программа поиска связок отношения] (* <- lang_ru;; *);
-	[agent scp-program of the ligaments relations] (* <- lang_en;; *);
+	[агентная scp-программа проверки отношения на транзитивность] (* <- lang_ru;; *);
+	[agent scp-program of testing relation for transitivity] (* <- lang_en;; *);
 	<- agent_scp_program;;
 
 scp_program -> agent_checking_whether_the_agent_is_a_transitive_relation 
 	(*
-	-> rrel_params: .agent_checking_whether_the_agent_is_a_transitive_relation_params 
+	-> rrel_params: ..agent_checking_whether_the_agent_is_a_transitive_relation_params 
 		(*
 		-> rrel_1: rrel_in: _event;;
 		-> rrel_2: rrel_in: _input_arc;;
 		*);;
 
-	-> rrel_operators: .agent_checking_whether_the_agent_is_a_transitive_relation_operator_set 
+	-> rrel_operators: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator_set 
 		(*
-		-> rrel_init: .agent_checking_whether_the_agent_is_a_transitive_relation_operator1 
+		-> rrel_init: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator1 
 			(*
 			<- searchElStr3;;
 			-> rrel_1: rrel_assign: rrel_scp_var: _temp;;
 			-> rrel_2: rrel_fixed: rrel_scp_var: _input_arc;;
 			-> rrel_3: rrel_assign: rrel_scp_var: _quest;;
 
-			=> nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator2;;
+			=> nrel_goto: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator2;;
 			*);;
 
-		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator2 
+
+		-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator2 
 			(*
 			<- searchElStr3;;
 			-> rrel_1: rrel_fixed: rrel_scp_const: question_checking_whether_the_agent_is_a_transitive_relation;;
 			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
 			-> rrel_3: rrel_fixed: rrel_scp_var: _quest;;
 
-			=> nrel_then: .agent_checking_whether_the_agent_is_a_transitive_relation_operator3;;
-			=> nrel_else: .agent_checking_whether_the_agent_is_a_transitive_relation_operator_return;;
+			=> nrel_then: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator3;;
+			=> nrel_else: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator_return;;
 			*);;
 
-		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator3
+
+		-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator3
 			(*
 			<- searchElStr3;;
 			-> rrel_1: rrel_fixed: rrel_scp_var: _quest;;
 			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
 			-> rrel_3: rrel_assign: rrel_scp_var: _param;;
 
-			=> nrel_then: .agent_checking_whether_the_agent_is_a_transitive_relation_operator4;;
-			=> nrel_else: .agent_checking_whether_the_agent_is_a_transitive_relation_operator_return;;
+			=> nrel_then: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator4;;
+			=> nrel_else: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator_return;;
 			*);;
 
-		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator4
+
+		-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator4
 			(*
 		 	<- genEl;;
 		 	-> rrel_1: rrel_assign: rrel_const: rrel_node: rrel_scp_var: _answer;;
 
-		 	=> nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator4A;;
+		 	=> nrel_goto: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator4A;;
 		 	*);;
 
-		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator4A
+
+		-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator4A
+			(*
+			<- searchElStr3;;
+
+		 	-> rrel_1: rrel_fixed: rrel_scp_const: binary_relation;;
+			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
+
+			=> nrel_then: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator4B;;	
+			=> nrel_else: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator_add_validating_message;;
+			*);;
+
+
+		-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator4B
 			(*
 			<- searchElStr3;;
 			-> rrel_1: rrel_scp_const: transitive_relation;;
 			-> rrel_2: rrel_assign: rrel_scp_var: rrel_const: rrel_perm: _arc;;
 			-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
 
-			=> nrel_then: .agent_checking_whether_the_agent_is_a_transitive_relation_operator19;;
-			=> nrel_else: .agent_checking_whether_the_agent_is_a_transitive_relation_operator5;;
+			=> nrel_then: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator19;;
+			=> nrel_else: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator5;;
 			*);;
 
-		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator5 
-			(*
-		 	<- genEl;;
-		 	-> rrel_1: rrel_assign: rrel_const: rrel_node: rrel_scp_var: _set_node;;
 
-		 	=> nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator6;;
-		 	*);;
-
-		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator6
-			(*
-		 	<- genEl;;
-		 	-> rrel_1: rrel_assign: rrel_const: rrel_node: rrel_scp_var: _set_dubl_node;;
-
-		 	=> nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator7;;
-		 	*);;
-
-		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator7
-			(*
-            <- printNl;;
-            -> rrel_1: rrel_scp_const: [в 1];;
-            
-            => nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator7p;;
-        	*);;
-
-		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator7p
+		-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator5
 			(*
 			<- searchSetStr5;;
-		 	-> rrel_1: rrel_assign: rrel_scp_var: rrel_node: _node1;;
+		 	-> rrel_1: rrel_assign: rrel_scp_var: rrel_node: _node_prev;;
 		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_common: _arc1;;
-		 	-> rrel_3: rrel_assign: rrel_scp_var: rrel_node: _node2;;
+		 	-> rrel_3: rrel_assign: rrel_scp_var: rrel_node: _node;;
             -> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc2;;
 			-> rrel_5: rrel_fixed: rrel_scp_var: _param;;
 
-            		-> rrel_set_1: rrel_fixed: rrel_scp_var: _set_dubl_node;;
-                 	-> rrel_set_3: rrel_fixed: rrel_scp_var: _set_dubl_node;;
+            -> rrel_set_3: rrel_assign: rrel_scp_var: _set_node;;
 
-           			=> nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator8A;;
-          			*);;
+           	=> nrel_goto: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator6;;
+          	*);;
 
-		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator8A
+
+     	-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator6
+			(*
+			<- searchSetStr5;;
+		 	-> rrel_1: rrel_assign: rrel_scp_var: rrel_node: _node_prev;;
+		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_common: _arc1;;
+		 	-> rrel_3: rrel_assign: rrel_scp_var: rrel_node: _node;;
+            -> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc2;;
+			-> rrel_5: rrel_fixed: rrel_scp_var: _param;;
+
+            -> rrel_set_1: rrel_assign: rrel_scp_var: _set_node_prev;;
+
+           	=> nrel_goto: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator7;;
+          	*);;
+
+
+		-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator7
 			(*
 			<- searchElStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _set_dubl_node;;
+		 	-> rrel_1: rrel_fixed: rrel_scp_var: _set_node;;
 		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
 		 	-> rrel_3: rrel_assign: rrel_scp_var: _node;;
 
-           	=> nrel_then: .agent_checking_whether_the_agent_is_a_transitive_relation_operator8B;;
-	       	=> nrel_else: .agent_checking_whether_the_agent_is_a_transitive_relation_operator8E;;
+           	=> nrel_then: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator8;;
+	       	=> nrel_else: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator18A;;
    			*);;
 
-   		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator8B
+
+   		-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator8
 			(*
             <- eraseEl;;
             -> rrel_1: rrel_fixed: rrel_scp_var: rrel_erase: _arc;;
             
-            => nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator8C;;
+            => nrel_goto: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator9;;
         	*);;
 
-        -> .agent_checking_whether_the_agent_is_a_transitive_relation_operator8C
+
+        -> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator9
 			(*
-			<- searchElStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _set_node;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
-		 	-> rrel_3: rrel_fixed: rrel_scp_var: _node;;
-
-           	=> nrel_then: .agent_checking_whether_the_agent_is_a_transitive_relation_operator8A;;
-	       	=> nrel_else: .agent_checking_whether_the_agent_is_a_transitive_relation_operator8D;;
-   			*);;
-
-   		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator8D
-			(*
-			<- genElStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _set_node;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
-		 	-> rrel_3: rrel_fixed: rrel_scp_var: _node;;
-
-           	=> nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator8A;;
-   			*);;
-
-   		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator8E
-			(*
-            <- eraseEl;;
-            -> rrel_1: rrel_fixed: rrel_scp_var: rrel_erase: _set_dubl_node;;
-            
-            => nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator9;;
-        	*);;
-
-        -> .agent_checking_whether_the_agent_is_a_transitive_relation_operator9
-			(*
-            <- printNl;;
-            -> rrel_1: rrel_scp_const: [в 2];;
-            
-            => nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator9p;;
-        	*);;
-
-        -> .agent_checking_whether_the_agent_is_a_transitive_relation_operator9p
-			(*
-			<- searchElStr5;;
-		 	-> rrel_1: rrel_assign: rrel_scp_var: rrel_node: _node_prew;;
+			<- searchSetStr5;;
+		 	-> rrel_1: rrel_fixed: rrel_scp_var: rrel_node: _node;;
 		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_common: _arc1;;
 		 	-> rrel_3: rrel_assign: rrel_scp_var: rrel_node: _node_next;;
             -> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc2;;
 			-> rrel_5: rrel_fixed: rrel_scp_var: _param;;
 
-           	=> nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator10;;
-          	*);;
+            -> rrel_set_3: rrel_assign: rrel_scp_var: _set_node_next;;
 
-        -> .agent_checking_whether_the_agent_is_a_transitive_relation_operator10
-			(*
-			<- eraseElStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _set_node;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: rrel_erase: _arc;;
-		 	-> rrel_3: rrel_fixed: rrel_scp_var: _node_prew;;
-
-           	=> nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator11;;
+           	=> nrel_then: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator10;;
+	       	=> nrel_else: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator7;;
    			*);;
 
-   		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator11
-			(*
-			<- eraseElStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _set_node;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: rrel_erase: _arc;;
-		 	-> rrel_3: rrel_fixed: rrel_scp_var: _node_next;;
-
-           	=> nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator12;;
-   			*);;
-
-   		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator12
-			(*
-		 	<- genEl;;
-		 	-> rrel_1: rrel_assign: rrel_const: rrel_node: rrel_scp_var: _set_next_or_prew;;
-
-		 	=> nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator13A;;
-		 	*);;
-
-   		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator13A
-			(*
-			<- searchSetStr5;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _node_next;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_common: _arc1;;
-		 	-> rrel_3: rrel_assign: rrel_scp_var: _node_temp;;
-            -> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc2;;
-			-> rrel_5: rrel_fixed: rrel_scp_var: _param;;
-
-            		-> rrel_set_3: rrel_fixed: rrel_scp_var: _set_next_or_prew;;
-
-           			=> nrel_then: .agent_checking_whether_the_agent_is_a_transitive_relation_operator14A;;
-           			=> nrel_else: .agent_checking_whether_the_agent_is_a_transitive_relation_operator15A;;
-          			*);;
-
-		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator14A
+		-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator10
 			(*
 			<- searchElStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _set_next_or_prew;;
+		 	-> rrel_1: rrel_fixed: rrel_scp_var: _set_node_next;;
 		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
 		 	-> rrel_3: rrel_assign: rrel_scp_var: _node_next;;
 
-           	=> nrel_then: .agent_checking_whether_the_agent_is_a_transitive_relation_operator14B;;
-	       	=> nrel_else: .agent_checking_whether_the_agent_is_a_transitive_relation_operator15A;;
+           	=> nrel_then: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator11;;
+	       	=> nrel_else: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator7;;
    			*);;
 
-		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator14B
+
+   		-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator11
 			(*
             <- eraseEl;;
             -> rrel_1: rrel_fixed: rrel_scp_var: rrel_erase: _arc;;
             
-            => nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator14C;;
+            => nrel_goto: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator12;;
         	*);;
 
-        -> .agent_checking_whether_the_agent_is_a_transitive_relation_operator14C
+
+        -> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator12
 			(*
 			<- searchElStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _set_node;;
+		 	-> rrel_1: rrel_fixed: rrel_scp_var: _set_node_prev;;
 		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
-		 	-> rrel_3: rrel_fixed: rrel_scp_var: _node_next;;
+		 	-> rrel_3: rrel_assign: rrel_scp_var: _node_prev;;
 
-           	=> nrel_then: .agent_checking_whether_the_agent_is_a_transitive_relation_operator14D;;
-	       	=> nrel_else: .agent_checking_whether_the_agent_is_a_transitive_relation_operator14A;;
+           	=> nrel_then: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator13;;
+	       	=> nrel_else: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator7;;
    			*);;
 
-   		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator14D
+
+   		-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator13
 			(*
             <- eraseEl;;
             -> rrel_1: rrel_fixed: rrel_scp_var: rrel_erase: _arc;;
             
-            => nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator14E;;
+            => nrel_goto: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator14;;
         	*);;
 
-   		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator14E
-			(*
-			<- eraseSetStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _set_next_or_prew;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: rrel_erase: _arc;;
-		 	-> rrel_3: rrel_assign: rrel_scp_var: _node_temp;;
 
-           	=> nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator13A;;
-   			*);;
-
-        -> .agent_checking_whether_the_agent_is_a_transitive_relation_operator15A
+        -> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator14
 			(*
-			<- searchSetStr5;;
-		 	-> rrel_1: rrel_assign: rrel_scp_var: _node_temp;;
+			<- searchElStr5;;
+		 	-> rrel_1: rrel_fixed: rrel_scp_var: rrel_node: _node_prev;;
 		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_common: _arc1;;
-		 	-> rrel_3: rrel_fixed: rrel_scp_var: _node_prew;;
+		 	-> rrel_3: rrel_fixed: rrel_scp_var: rrel_node: _node_next;;
             -> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc2;;
 			-> rrel_5: rrel_fixed: rrel_scp_var: _param;;
 
-            		-> rrel_set_1: rrel_fixed: rrel_scp_var: _set_next_or_prew;;
-
-           			=> nrel_then: .agent_checking_whether_the_agent_is_a_transitive_relation_operator16A;;
-           			=> nrel_else: .agent_checking_whether_the_agent_is_a_transitive_relation_operator17_controll;;
-          			*);;
-
-		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator16A
-			(*
-			<- searchElStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _set_next_or_prew;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
-		 	-> rrel_3: rrel_assign: rrel_scp_var: _node_prew;;
-
-           	=> nrel_then: .agent_checking_whether_the_agent_is_a_transitive_relation_operator16B;;
-	       	=> nrel_else: .agent_checking_whether_the_agent_is_a_transitive_relation_operator17_controll;;
+           	=> nrel_then: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator19A;;
+	       	=> nrel_else: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator10;;
    			*);;
 
-		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator16B
+
+   		-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator15
 			(*
             <- eraseEl;;
-            -> rrel_1: rrel_fixed: rrel_scp_var: rrel_erase: _arc;;
+            -> rrel_1: rrel_fixed: rrel_scp_var: rrel_erase: _set_node_next;;
             
-            => nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator16C;;
+            => nrel_goto: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator16;;
         	*);;
 
-        -> .agent_checking_whether_the_agent_is_a_transitive_relation_operator16C
-			(*
-			<- searchElStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _set_node;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
-		 	-> rrel_3: rrel_fixed: rrel_scp_var: _node_prew;;
 
-           	=> nrel_then: .agent_checking_whether_the_agent_is_a_transitive_relation_operator16D;;
-	       	=> nrel_else: .agent_checking_whether_the_agent_is_a_transitive_relation_operator17_controll;;
-   			*);;
-
-   		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator16D
-			(*
-            <- eraseEl;;
-            -> rrel_1: rrel_fixed: rrel_scp_var: rrel_erase: _arc;;
-            
-            => nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator16E;;
-        	*);;
-
-   		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator16E
-			(*
-			<- eraseSetStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _set_next_or_prew;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: rrel_erase: _arc;;
-		 	-> rrel_3: rrel_assign: rrel_scp_var: _node_temp;;
-
-           	=> nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator15A;;
-   			*);;
-
-        -> .agent_checking_whether_the_agent_is_a_transitive_relation_operator17_controll
-			(*
-			<- searchElStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _set_node;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
-		 	-> rrel_3: rrel_assign: rrel_scp_var: _node_temp;;
-
-           	=> nrel_then: .agent_checking_whether_the_agent_is_a_transitive_relation_operator18;;
-           	=> nrel_else: .agent_checking_whether_the_agent_is_a_transitive_relation_operator17;;
-   			*);;
-
-        -> .agent_checking_whether_the_agent_is_a_transitive_relation_operator17
-			(*
-			<- genElStr3;;
-		 	-> rrel_1: rrel_scp_const: transitive_relation;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
-		 	-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
-
-           	=> nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator_erase_set_node;;
-   			*);;
-
-   		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator18
-			(*
-			<- genElStr3;;
-		 	-> rrel_1: rrel_scp_const: transitive_relation;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_neg: rrel_const: rrel_perm: _arc;;
-		 	-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
-
-           	=> nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator_erase_set_node;;
-   			*);;
-
-   		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator_erase_set_node
+   		-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator16
 			(*
             <- eraseEl;;
             -> rrel_1: rrel_fixed: rrel_scp_var: rrel_erase: _set_node;;
             
-            => nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator19;;
+            => nrel_goto: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator17;;
         	*);;
 
-   		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator19
+
+        -> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator17
+			(*
+            <- eraseEl;;
+            -> rrel_1: rrel_fixed: rrel_scp_var: rrel_erase: _set_node_prev;;
+            
+            => nrel_goto: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator_return;;
+        	*);;
+
+
+        -> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator18A
+			(*
+			<- genElStr3;;
+		 	-> rrel_1: rrel_scp_const: antitransitive_relation;;
+		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
+		 	-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
+
+           	=> nrel_goto: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator18;;
+   			*);;
+
+
+  		-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator18
+			(*
+			<- genElStr3;;
+		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
+		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
+		 	-> rrel_3: rrel_scp_const: antitransitive_relation;;
+
+           	=> nrel_goto: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator20;;
+   			*);;
+
+
+        -> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator19A
+			(*
+			<- genElStr3;;
+		 	-> rrel_1: rrel_scp_const: transitive_relation;;
+		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
+		 	-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
+
+           	=> nrel_goto: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator19;;
+   			*);;
+
+
+  		-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator19
 			(*
 			<- genElStr3;;
 		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
 		 	-> rrel_3: rrel_scp_const: transitive_relation;;
 
-           	=> nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator20;;
+           	=> nrel_goto: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator20;;
    			*);;
 
-   		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator20
+
+   		-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator20
 			(*
 			<- genElStr3;;
 		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
 		 	-> rrel_3: rrel_fixed: rrel_scp_var: _arc;;
 
-           	=> nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator_add_param;;
+           	=> nrel_goto: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator21;;
    			*);;
 
-		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator_add_param
+
+		-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator21
 			(*
 		 	<- genElStr3;;
 		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
 		 	-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
 
-            => nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator_gen_answer;;
+            => nrel_goto: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator22;;
 		 	*);;
 
-		-> .agent_checking_whether_the_agent_is_a_transitive_relation_operator_gen_answer 
+
+		-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator22 
 			(*
 		  	<- genElStr5;;
 		  	-> rrel_1: rrel_fixed: rrel_scp_var: _quest;;
@@ -404,10 +307,44 @@ scp_program -> agent_checking_whether_the_agent_is_a_transitive_relation
 		  	-> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc2;;
 		  	-> rrel_5: rrel_fixed: rrel_scp_const: nrel_answer;;
 
-		  	=> nrel_goto: .agent_checking_whether_the_agent_is_a_transitive_relation_operator_return;;
+		  	=> nrel_goto: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator_succesfull;;
 			*);;    
 
-		 -> .agent_checking_whether_the_agent_is_a_transitive_relation_operator_return 
+
+		-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator_succesfull
+			(*
+			<- genElStr3;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_const: question_finished_successfully;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _quest;;
+
+			=> nrel_goto: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator15;;
+			*);;
+
+
+		-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator_add_validating_message
+			(*
+            <- printNl;;
+            -> rrel_1: rrel_scp_const: [Wrong parametr! It must be binary relation.];;
+
+		  	=> nrel_goto: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator_gen_unsucces;;
+			*);;
+
+
+		-> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator_gen_unsucces
+			(*
+			<- genElStr3;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_const: question_finished_unsuccessfully;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _quest;;
+
+			=> nrel_goto: ..agent_checking_whether_the_agent_is_a_transitive_relation_operator15;; 
+			*);;
+
+
+		 -> ..agent_checking_whether_the_agent_is_a_transitive_relation_operator_return 
 			(*
 		  	<- return;;
 			*);;

--- a/kb_main/agents/agents_operations_on_relations/agent_definitional_domain/agent_of_finding_domain.scsi
+++ b/kb_main/agents/agents_operations_on_relations/agent_definitional_domain/agent_of_finding_domain.scsi
@@ -6,63 +6,59 @@ agent_of_finding_domain
 
 scp_program -> agent_of_finding_domain 
 	(*
-	-> rrel_params: .agent_of_finding_domain_params 
+	-> rrel_params: ..agent_of_finding_domain_params 
 		(*
 		-> rrel_1: rrel_in: _event;;
 		-> rrel_2: rrel_in: _input_arc;;
 		*);;
 
-	-> rrel_operators: .agent_of_finding_domain_operator_set 
+	-> rrel_operators: ..agent_of_finding_domain_operator_set 
 		(*
-		-> rrel_init: .agent_of_finding_domain_operator1 
+		-> rrel_init: ..agent_of_finding_domain_operator1 
 			(*
 			<- searchElStr3;;
 			-> rrel_1: rrel_assign: rrel_scp_var: _temp;;
 			-> rrel_2: rrel_fixed: rrel_scp_var: _input_arc;;
 			-> rrel_3: rrel_assign: rrel_scp_var: _quest;;
 
-			=> nrel_goto: .agent_of_finding_domain_operator2;;
+			=> nrel_goto: ..agent_of_finding_domain_operator2;;
 			*);;
 
-		-> .agent_of_finding_domain_operator2 
+
+		-> ..agent_of_finding_domain_operator2 
 			(*
 			<- searchElStr3;;
 			-> rrel_1: rrel_fixed: rrel_scp_const: question_of_finding_domain;;
 			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
 			-> rrel_3: rrel_fixed: rrel_scp_var: _quest;;
 
-			=> nrel_then: .agent_of_finding_domain_operator3A;;
-			=> nrel_else: .agent_of_finding_domain_operator_return;;
+			=> nrel_then: ..agent_of_finding_domain_operator3Ap;;
+			=> nrel_else: ..agent_of_finding_domain_operator_return;;
 			*);;
 
-		-> .agent_of_finding_domain_operator3A 
-			(*
-		 	<- printNl;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_const: [агент поиска доменов и области определения];;
 
-		 	=> nrel_goto: .agent_of_finding_domain_operator3Ap;;
-		 	*);;
-
-		-> .agent_of_finding_domain_operator3Ap
+		-> ..agent_of_finding_domain_operator3Ap
 			(*
 			<- searchElStr3;;
 			-> rrel_1: rrel_fixed: rrel_scp_var: _quest;;
 			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
 			-> rrel_3: rrel_assign: rrel_scp_var: _param;;
 
-			=> nrel_then: .agent_of_finding_domain_operator3B;;
-			=> nrel_else: .agent_of_finding_domain_operator_return;;
+			=> nrel_then: ..agent_of_finding_domain_operator3B;;
+			=> nrel_else: ..agent_of_finding_domain_operator_return;;
 			*);;
 
-		-> .agent_of_finding_domain_operator3B 
+
+		-> ..agent_of_finding_domain_operator3B 
 			(*
 		 	<- genEl;;
 		 	-> rrel_1: rrel_assign: rrel_const: rrel_node: rrel_scp_var: _answer;;
 
-		 	=> nrel_goto: .agent_of_finding_domain_operator4A;;
+		 	=> nrel_goto: ..agent_of_finding_domain_operator4A;;
 		 	*);;
 
-		-> .agent_of_finding_domain_operator4A
+
+		-> ..agent_of_finding_domain_operator4A
 			(*
 			<- searchSetStr5;;
 			-> rrel_1: rrel_fixed: rrel_scp_var: _param;;
@@ -71,33 +67,27 @@ scp_program -> agent_of_finding_domain
             -> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc2;;
 		 	-> rrel_5: rrel_fixed: rrel_scp_const: nrel_first_domain;;
 
-                 	-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
-                 	-> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
-		 			-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
+		 	-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
 
-                 	=> nrel_then: .agent_of_finding_domain_operator4A_domain;;
-		 			=> nrel_else: .agent_of_finding_domain_operator7D;;
-                 	*);;
+            => nrel_then: ..agent_of_finding_domain_operator4A_domain;;
+		 	=> nrel_else: ..agent_of_finding_domain_operator7D;;
+            *);;
 
-		-> .agent_of_finding_domain_operator4A_domain
+
+		-> ..agent_of_finding_domain_operator4A_domain
 			(*
 		 	<- genElStr3;;
 		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 		 	-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc2;;
 		 	-> rrel_3: rrel_fixed: rrel_scp_const: nrel_first_domain;;
 
-            => nrel_goto: .agent_of_finding_domain_operator4B;;
+            => nrel_goto: ..agent_of_finding_domain_operator4Bp;;
 		 	*);;
 
-		-> .agent_of_finding_domain_operator4B
-			(*
-		 	<- printNl;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_const: [первый домен];;
 
-		 	=> nrel_goto: .agent_of_finding_domain_operator4Bp;;
-		 	*);;
-
-		-> .agent_of_finding_domain_operator4Bp
+		-> ..agent_of_finding_domain_operator4Bp
 			(*
 		 	<- searchSetStr5;;
 		 	-> rrel_1: rrel_assign: rrel_scp_var: _comb1;;
@@ -106,38 +96,41 @@ scp_program -> agent_of_finding_domain
             -> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc2;;
 		 	-> rrel_5: rrel_fixed: rrel_scp_const: nrel_combination;;
 	         
-					-> rrel_set_1: rrel_fixed: rrel_scp_var: _answer;;
-             	 	-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
-		 			-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
+			-> rrel_set_1: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+		 	-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
 
-                 	=> nrel_then: .agent_of_finding_domain_operator4C_combination;;
-                 	=> nrel_else: .agent_of_finding_domain_operator5A;;
-                 	*);;
+            => nrel_then: ..agent_of_finding_domain_operator4C_combination;;
+            => nrel_else: ..agent_of_finding_domain_operator5A;;
+            *);;
 
-		-> .agent_of_finding_domain_operator4C_combination 
+
+		-> ..agent_of_finding_domain_operator4C_combination 
 			(*
 		 	<- genElStr3;;
 		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 		 	-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc3;;
 		 	-> rrel_3: rrel_fixed: rrel_scp_const: nrel_combination;;
 
-            => nrel_goto: .agent_of_finding_domain_operator4C;;
+            => nrel_goto: ..agent_of_finding_domain_operator4C;;
 		 	*);;
 
-		-> .agent_of_finding_domain_operator4C
+
+		-> ..agent_of_finding_domain_operator4C
 			(*
 		 	<- searchSetStr3;;
 			-> rrel_1: rrel_fixed: rrel_scp_var: _comb1;;
 		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
 		 	-> rrel_3: rrel_assign: rrel_scp_var: _inst1;;
                  
-                 	-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
-                 	-> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
 
-                 	=> nrel_goto: .agent_of_finding_domain_operator5A;;
-                 	*);;		
+            => nrel_goto: ..agent_of_finding_domain_operator5A;;
+            *);;		
 		
-		-> .agent_of_finding_domain_operator5A
+
+		-> ..agent_of_finding_domain_operator5A
 			(*
 		 	<- searchSetStr5;;
 		 	-> rrel_1: rrel_fixed: rrel_scp_var: _param;;
@@ -146,25 +139,27 @@ scp_program -> agent_of_finding_domain
             -> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc2;;
 		 	-> rrel_5: rrel_fixed: rrel_scp_const: nrel_second_domain;;
 
-             	 	-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
-                 	-> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
-		 			-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
+		 	-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
 
-                 	=> nrel_then: .agent_of_finding_domain_operator5A_domain;;
-                 	=> nrel_else: .agent_of_finding_domain_operator7A;;
-                 	*);;
+            => nrel_then: ..agent_of_finding_domain_operator5A_domain;;
+            => nrel_else: ..agent_of_finding_domain_operator7A;;
+            *);;
 
-		-> .agent_of_finding_domain_operator5A_domain
+
+		-> ..agent_of_finding_domain_operator5A_domain
 			(*
 		 	<- genElStr3;;
 		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 		 	-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc3;;
 		 	-> rrel_3: rrel_fixed: rrel_scp_const: nrel_second_domain;;
 
-            => nrel_goto: .agent_of_finding_domain_operator5B;;
+            => nrel_goto: ..agent_of_finding_domain_operator5B;;
 		 	*);;
 
-		-> .agent_of_finding_domain_operator5B
+
+		-> ..agent_of_finding_domain_operator5B
 			(*
 		 	<- searchSetStr5;;
 		 	-> rrel_1: rrel_assign: rrel_scp_var: _comb2;;
@@ -173,49 +168,53 @@ scp_program -> agent_of_finding_domain
             -> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc2;;
 		 	-> rrel_5: rrel_fixed: rrel_scp_const: nrel_combination;;
 	         
-					-> rrel_set_1: rrel_fixed: rrel_scp_var: _answer;;
-             	 	-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
-		 			-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
+			-> rrel_set_1: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+		 	-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
 
-                 	=> nrel_then: .agent_of_finding_domain_operator5C_combination1;;
-                 	=> nrel_else: .agent_of_finding_domain_operator6A;;
-                 	*);;
+            => nrel_then: ..agent_of_finding_domain_operator5C_combination1;;
+            => nrel_else: ..agent_of_finding_domain_operator6A;;
+            *);;
 
-		-> .agent_of_finding_domain_operator5C_combination1 
+
+		-> ..agent_of_finding_domain_operator5C_combination1 
 			(*
 		 	<- searchElStr3;;
 		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 		 	-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc3;;
 		 	-> rrel_3: rrel_fixed: rrel_scp_const: nrel_combination;;
 
-            => nrel_then: .agent_of_finding_domain_operator5C;;
-            => nrel_else: .agent_of_finding_domain_operator5C_combination2;;
+            => nrel_then: ..agent_of_finding_domain_operator5C;;
+            => nrel_else: ..agent_of_finding_domain_operator5C_combination2;;
 		 	*);;
 
-		-> .agent_of_finding_domain_operator5C_combination2 
+
+		-> ..agent_of_finding_domain_operator5C_combination2 
 			(*
 		 	<- genElStr3;;
 		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 		 	-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc3;;
 		 	-> rrel_3: rrel_fixed: rrel_scp_const: nrel_combination;;
 
-            => nrel_goto: .agent_of_finding_domain_operator5C;;
+            => nrel_goto: ..agent_of_finding_domain_operator5C;;
 		 	*);;
 
-		-> .agent_of_finding_domain_operator5C
+
+		-> ..agent_of_finding_domain_operator5C
 			(*
 		 	<- searchSetStr3;;
 		 	-> rrel_1: rrel_fixed: rrel_scp_var: _comb2;;
 		 	-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 		 	-> rrel_3: rrel_assign: rrel_scp_var: _inst2;;
                  
-            		-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
-		 			-> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+		 	-> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
 
-                 	=> nrel_goto: .agent_of_finding_domain_operator6A;;
-                 	*);;
+            => nrel_goto: ..agent_of_finding_domain_operator6A;;
+            *);;
 
-		-> .agent_of_finding_domain_operator6A
+
+		-> ..agent_of_finding_domain_operator6A
 			(*
 		 	<- searchSetStr5;;
 		 	-> rrel_1: rrel_fixed: rrel_scp_var: _param;;
@@ -224,25 +223,27 @@ scp_program -> agent_of_finding_domain
             -> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc2;;
 		 	-> rrel_5: rrel_fixed: rrel_scp_const: nrel_third_domain;;
 
-                 	-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
-                 	-> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
-		 			-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
+		 	-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
 
-                 	=> nrel_then: .agent_of_finding_domain_operator6A_domain;;
-		 			=> nrel_else: .agent_of_finding_domain_operator7A;;
-                 	*);;
+            => nrel_then: ..agent_of_finding_domain_operator6A_domain;;
+		 	=> nrel_else: ..agent_of_finding_domain_operator7A;;
+            *);;
 
-		-> .agent_of_finding_domain_operator6A_domain
+
+		-> ..agent_of_finding_domain_operator6A_domain
 			(*
 		 	<- genElStr3;;
 		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 		 	-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 		 	-> rrel_3: rrel_fixed: rrel_scp_const: nrel_third_domain;;
 
-            => nrel_goto: .agent_of_finding_domain_operator6B;;
+            => nrel_goto: ..agent_of_finding_domain_operator6B;;
 		 	*);;
 
-        -> .agent_of_finding_domain_operator6B
+
+        -> ..agent_of_finding_domain_operator6B
 			(*
 		 	<- searchSetStr5;;
 		 	-> rrel_1: rrel_assign: rrel_scp_var: _comb3;;
@@ -251,49 +252,53 @@ scp_program -> agent_of_finding_domain
             -> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc2;;
 		 	-> rrel_5: rrel_fixed: rrel_scp_const: nrel_combination;;
 	         
-             	 	-> rrel_set_1: rrel_fixed: rrel_scp_var: _answer;;
-					-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
-		 			-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_set_1: rrel_fixed: rrel_scp_var: _answer;;
+			-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+		 	-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
 
-                 	=> nrel_then: .agent_of_finding_domain_operator6C_combination1;;
-                 	=> nrel_else: .agent_of_finding_domain_operator7A;;
-                 	*);;
+            => nrel_then: ..agent_of_finding_domain_operator6C_combination1;;
+            => nrel_else: ..agent_of_finding_domain_operator7A;;
+            *);;
 
-		-> .agent_of_finding_domain_operator6C_combination1 
+
+		-> ..agent_of_finding_domain_operator6C_combination1 
 			(*
 		 	<- searchElStr3;;
 		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 		 	-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc3;;
 		 	-> rrel_3: rrel_fixed: rrel_scp_const: nrel_combination;;
 
-            => nrel_then: .agent_of_finding_domain_operator6C;;
-            => nrel_else: .agent_of_finding_domain_operator6C_combination2;;
+            => nrel_then: ..agent_of_finding_domain_operator6C;;
+            => nrel_else: ..agent_of_finding_domain_operator6C_combination2;;
 		 	*);;
 
-		-> .agent_of_finding_domain_operator6C_combination2 
+
+		-> ..agent_of_finding_domain_operator6C_combination2 
 			(*
 		 	<- genElStr3;;
 		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 		 	-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc3;;
 		 	-> rrel_3: rrel_fixed: rrel_scp_const: nrel_combination;;
 
-            => nrel_goto: .agent_of_finding_domain_operator6C;;
+            => nrel_goto: ..agent_of_finding_domain_operator6C;;
 		 	*);;
 
-		-> .agent_of_finding_domain_operator6C
+
+		-> ..agent_of_finding_domain_operator6C
 			(*
 		 	<- searchSetStr3;;
 		 	-> rrel_1: rrel_fixed: rrel_scp_var: _comb3;;
 		 	-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 		 	-> rrel_3: rrel_assign: rrel_scp_var: _inst3;;
                  
-            		-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
-		 			-> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+		 	-> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
 
-                 	=> nrel_goto: .agent_of_finding_domain_operator7A;;
-                 	*);;
+            => nrel_goto: ..agent_of_finding_domain_operator7A;;
+            *);;
 
-		-> .agent_of_finding_domain_operator7A
+
+		-> ..agent_of_finding_domain_operator7A
 			(*
 		 	<- searchSetStr5;;
 		 	-> rrel_1: rrel_fixed: rrel_scp_var: _param;;
@@ -302,26 +307,28 @@ scp_program -> agent_of_finding_domain
             -> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc2;;
 		 	-> rrel_5: rrel_fixed: rrel_scp_const: nrel_definitional_domain;;
 
-                 	-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
-                 	-> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
-		 			-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
+		 	-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
 
-                 	=> nrel_then: .agent_of_finding_domain_operator7B_definitional_domain;;
-                 	// если не нашли, добавляем что есть в ответ
-		 			=> nrel_else: .agent_of_finding_domain_operator7D;;
-                 	*);;
+            => nrel_then: ..agent_of_finding_domain_operator7B_definitional_domain;;
+            // если не нашли, добавляем что есть в ответ
+		 	=> nrel_else: ..agent_of_finding_domain_operator7D;;
+            *);;
 
-		-> .agent_of_finding_domain_operator7B_definitional_domain
+
+		-> ..agent_of_finding_domain_operator7B_definitional_domain
 			(*
 		 	<- genElStr3;;
 		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 		 	-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc2;;
 		 	-> rrel_3: rrel_fixed: rrel_scp_const: nrel_definitional_domain;;
 
-            => nrel_goto: .agent_of_finding_domain_operator7B;;
+            => nrel_goto: ..agent_of_finding_domain_operator7B;;
 		 	*);;
 
-		-> .agent_of_finding_domain_operator7B
+
+		-> ..agent_of_finding_domain_operator7B
 			(*
 		 	<- searchSetStr5;;
 		 	-> rrel_1: rrel_assign: rrel_scp_var: _comb4;;
@@ -330,37 +337,40 @@ scp_program -> agent_of_finding_domain
             -> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc2;;
 		 	-> rrel_5: rrel_fixed: rrel_scp_const: nrel_combination;;
 
-                 	-> rrel_set_1: rrel_fixed: rrel_scp_var: _answer;;
-		 			-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
-		 			-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_set_1: rrel_fixed: rrel_scp_var: _answer;;
+		 	-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+		 	-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
 
-                 	=> nrel_then: .agent_of_finding_domain_operator7C;;
-		 			=> nrel_else: .agent_of_finding_domain_operator7D;;
-                 	*);;
+            => nrel_then: ..agent_of_finding_domain_operator7C;;
+		 	=> nrel_else: ..agent_of_finding_domain_operator7D;;
+            *);;
 
-		-> .agent_of_finding_domain_operator7C 
+
+		-> ..agent_of_finding_domain_operator7C 
 			(*
 		  	<- searchSetStr3;;
 		  	-> rrel_1: rrel_fixed: rrel_scp_var: _comb4;;
 		  	-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc5;;
 		  	-> rrel_3: rrel_assign: rrel_scp_var: _inst4;;
 
-					-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+			-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
 
-		  			=> nrel_goto: .agent_of_finding_domain_operator7D;;
+		  	=> nrel_goto: ..agent_of_finding_domain_operator7D;;
 		 	*);;
 
-		-> .agent_of_finding_domain_operator7D 
+
+		-> ..agent_of_finding_domain_operator7D 
 			(*
 		 	<- genElStr3;;
 		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 		 	-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 		 	-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
 
-            => nrel_goto: .agent_of_finding_domain_operator_gen_answer;;
+            => nrel_goto: ..agent_of_finding_domain_operator_gen_answer;;
 		 	*);;
 
-		-> .agent_of_finding_domain_operator_gen_answer 
+
+		-> ..agent_of_finding_domain_operator_gen_answer 
 			(*
 		  	<- genElStr5;;
 		  	-> rrel_1: rrel_fixed: rrel_scp_var: _quest;;
@@ -369,14 +379,25 @@ scp_program -> agent_of_finding_domain
 		  	-> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc2;;
 		  	-> rrel_5: rrel_fixed: rrel_scp_const: nrel_answer;;
 
-		  	=> nrel_goto: .agent_of_finding_domain_operator_return;;
+		  	=> nrel_goto: ..agent_of_finding_domain_operator_succesfull;;
 			*);;    
 
-		 -> .agent_of_finding_domain_operator_return 
+
+		-> ..agent_of_finding_domain_operator_succesfull
+			(*
+			<- genElStr3;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_const: question_finished_successfully;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _quest;;
+
+			=> nrel_goto: ..agent_of_finding_domain_operator_return;;
+			*);;
+
+
+		 -> ..agent_of_finding_domain_operator_return 
 			(*
 		  	<- return;;
 			*);;
 		*);;
 	*);;
-
-

--- a/kb_main/agents/agents_operations_on_relations/agent_of_finding_relations_reflexive_propertes/agent_of_finding_relations_reflexive_propertes.scsi
+++ b/kb_main/agents/agents_operations_on_relations/agent_of_finding_relations_reflexive_propertes/agent_of_finding_relations_reflexive_propertes.scsi
@@ -5,75 +5,140 @@ agent_of_finding_relations_reflexive_propertes
 
 	[agent scp-program of finding relation's reflexive propertes] 
 	(* <- lang_en;; *);
-
 <- agent_scp_program;;
 
 scp_program -> agent_of_finding_relations_reflexive_propertes 
 	(*
-	-> rrel_params: .agent_of_finding_relations_reflexive_propertes_params 
+	-> rrel_params: ..agent_of_finding_relations_reflexive_propertes_params 
 		(*
 		-> rrel_1: rrel_in: _event;;
 		-> rrel_2: rrel_in: _input_arc;;
 		*);;
 
-	->rrel_operators: .agent_of_finding_relations_reflexive_propertes_operator_set (*
-
-		->rrel_init: .agent_of_finding_relations_reflexive_propertes_operator1 (*
+	->rrel_operators: ..agent_of_finding_relations_reflexive_propertes_operator_set 
+		(*
+		->rrel_init: ..agent_of_finding_relations_reflexive_propertes_operator1 
+			(*
 			<- searchElStr3;;
 			-> rrel_1: rrel_assign: rrel_scp_var: _temp;;
 			-> rrel_2: rrel_fixed: rrel_scp_var: _input_arc;;
 			-> rrel_3: rrel_assign: rrel_scp_var: _quest;;
-			=>nrel_goto: .agent_of_finding_relations_reflexive_propertes_operator2;;
-		*);;
 
-		-> .agent_of_finding_relations_reflexive_propertes_operator2 (*
+			=>nrel_goto: ..agent_of_finding_relations_reflexive_propertes_operator2;;
+			*);;
+
+
+		-> ..agent_of_finding_relations_reflexive_propertes_operator2 
+			(*
 			<- searchElStr3;;
 			-> rrel_1: rrel_fixed: rrel_scp_const: question_finding_relations_reflexive_propertes;;
 			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
 			-> rrel_3: rrel_fixed: rrel_scp_var: _quest;;
-			=>nrel_then: .agent_of_finding_relations_reflexive_propertes_operator3;;
-			=>nrel_else: .agent_of_finding_relations_reflexive_propertes_operator_return;;
-		*);;
 
-		-> .agent_of_finding_relations_reflexive_propertes_operator3 (*
+			=>nrel_then: ..agent_of_finding_relations_reflexive_propertes_operator3;;
+			=>nrel_else: ..agent_of_finding_relations_reflexive_propertes_operator_return;;
+			*);;
+
+
+		-> ..agent_of_finding_relations_reflexive_propertes_operator3 
+			(*
 			<- searchElStr3;;
 			-> rrel_1: rrel_fixed: rrel_scp_var: _quest;;
 			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
 			-> rrel_3: rrel_assign: rrel_scp_var: _param;;
-			=>nrel_then: .agent_of_finding_relations_reflexive_propertes_operator5;;
-			=>nrel_else: .agent_of_finding_relations_reflexive_propertes_operator_return;;
-		*);;
+
+			=>nrel_then: ..agent_of_finding_relations_reflexive_propertes_operator4A;;
+			=>nrel_else: ..agent_of_finding_relations_reflexive_propertes_operator_return;;
+			*);;
+
+
+		-> ..agent_of_finding_relations_reflexive_propertes_operator4A
+			(*
+			<- searchElStr3;;
+
+		 	-> rrel_1: rrel_fixed: rrel_scp_const: binary_relation;;
+			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
+
+			=> nrel_then: ..agent_of_finding_relations_reflexive_propertes_operator5;;	
+			=> nrel_else: ..agent_of_finding_relations_reflexive_propertes_operator_add_validating_message;;
+			*);;
 		
-		-> .agent_of_finding_relations_reflexive_propertes_operator5 (*
+
+		-> ..agent_of_finding_relations_reflexive_propertes_operator5 
+			(*
 			<- call;; 
 			-> rrel_1: rrel_fixed: rrel_scp_const:  proc_of_finding_relations_reflexive_propertes ;;
-			->rrel_2:rrel_fixed:rrel_scp_const: 
-			.agent_of_finding_relations_reflexive_propertes_operator5_params (*
+			-> rrel_2:rrel_fixed:rrel_scp_const: 
+			..agent_of_finding_relations_reflexive_propertes_operator5_params 
+				(*
 				-> rrel_1: rrel_fixed: rrel_scp_var: _param;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _answer;;
-			*);;
+				*);;
 			-> rrel_3: rrel_assign: rrel_scp_var: _descr;;
-			=>nrel_goto: .agent_of_finding_relations_reflexive_propertes_operator6;;
-		*);;
 
-		-> .agent_of_finding_relations_reflexive_propertes_operator6 (*
+			=>nrel_goto: ..agent_of_finding_relations_reflexive_propertes_operator6;;
+			*);;
+
+
+		-> ..agent_of_finding_relations_reflexive_propertes_operator6 
+			(*
 			<- waitReturn;;
 			-> rrel_1: rrel_fixed: rrel_scp_var: _descr;;
-			=>nrel_goto: .agent_of_finding_relations_reflexive_propertes_operator_gen_answer;;
-		*);;
 
-		-> .agent_of_finding_relations_reflexive_propertes_operator_gen_answer (*
+			=>nrel_goto: ..agent_of_finding_relations_reflexive_propertes_operator_gen_answer;;
+			*);;
+
+
+		-> ..agent_of_finding_relations_reflexive_propertes_operator_gen_answer 
+			(*
 			<- genElStr5;;
 			-> rrel_1: rrel_fixed: rrel_scp_var: _quest;;
 			-> rrel_2: rrel_assign: rrel_const: rrel_common: rrel_scp_var: _arc;;
 			-> rrel_3: rrel_fixed: rrel_scp_var: _answer;;
 			-> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc2;;
 			-> rrel_5: rrel_fixed: rrel_scp_const: nrel_answer;;
-			=>nrel_goto: .agent_of_finding_relations_reflexive_propertes_operator_return;;
-		*);;
 
-		-> .agent_of_finding_relations_reflexive_propertes_operator_return (*
+			=>nrel_goto: ..agent_of_finding_relations_reflexive_propertes_operator_succesfull;;
+			*);;
+
+
+		-> ..agent_of_finding_relations_reflexive_propertes_operator_succesfull
+			(*
+			<- genElStr3;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_const: question_finished_successfully;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _quest;;
+
+			=> nrel_goto: ..agent_of_finding_relations_reflexive_propertes_operator_return;;
+			*);;  
+
+
+		-> ..agent_of_finding_relations_reflexive_propertes_operator_add_validating_message
+			(*
+            <- printNl;;
+            -> rrel_1: rrel_scp_const: [Wrong parametr! It must be binary relation.];;
+
+		  	=> nrel_goto: ..agent_of_finding_relations_reflexive_propertes_operator_gen_unsucces;;
+			*);;
+
+
+		-> ..agent_of_finding_relations_reflexive_propertes_operator_gen_unsucces
+			(*
+			<- genElStr3;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_const: question_finished_unsuccessfully;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _quest;;
+
+			=> nrel_goto: ..agent_of_finding_relations_reflexive_propertes_operator_return;; 
+			*);;
+
+
+		-> ..agent_of_finding_relations_reflexive_propertes_operator_return 
+			(*
 			<- return;;
+			*);;
 		*);;
 	*);;
-*);;

--- a/kb_main/agents/agents_operations_on_relations/agent_of_finding_relations_reflexive_propertes/proc_of_finding_relations_reflexive_propertes.scs
+++ b/kb_main/agents/agents_operations_on_relations/agent_of_finding_relations_reflexive_propertes/proc_of_finding_relations_reflexive_propertes.scs
@@ -1,277 +1,318 @@
 scp_program -> proc_of_finding_relations_reflexive_propertes 
 	(*	
-	-> rrel_params: .proc_of_finding_relations_reflexive_propertes_params 
+	-> rrel_params: ..proc_of_finding_relations_reflexive_propertes_params 
 		(*
 		-> rrel_1: rrel_in: _A;;
 		-> rrel_2: rrel_out: _answer;;
 		*);;
 
-	-> rrel_operators: .proc_of_finding_relations_reflexive_propertes_operator_set 
+	-> rrel_operators: ..proc_of_finding_relations_reflexive_propertes_operator_set 
 		(*
-		-> rrel_init: .proc_of_finding_relations_reflexive_propertes_operator0 (*
-				<- printNl;;
-				-> rrel_1: rrel_fixed: rrel_scp_const: [агент нахождения рефлексивных свойств отношения];;
-				=> nrel_goto: .proc_of_finding_relations_reflexive_propertes_operator1;;
-	   		*);;
+		-> rrel_init: ..proc_of_finding_relations_reflexive_propertes_operator1 
+			(*
+			<- genEl;;
+			-> rrel_1: rrel_assign: rrel_const: rrel_node: rrel_scp_var: _result;;
 
-	    	-> .proc_of_finding_relations_reflexive_propertes_operator1 (*
-				<- genEl;;
-				-> rrel_1: rrel_assign: rrel_const: rrel_node: rrel_scp_var: _result;;
-				=> nrel_goto: .proc_of_finding_relations_reflexive_propertes_operator2;;
+			=> nrel_goto: ..proc_of_finding_relations_reflexive_propertes_operator2;;
 			*);;
 
-			-> .proc_of_finding_relations_reflexive_propertes_operator2 (*
-				<- searchElStr3;;
-				-> rrel_1: rrel_fixed: rrel_scp_const: reflexive_relation;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
-				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_reflexive_propertes_operator5;;
-	                 	=> nrel_else: .proc_of_finding_relations_reflexive_propertes_operator6;;
+		-> ..proc_of_finding_relations_reflexive_propertes_operator2 
+			(*
+			<- searchElStr3;;
+			-> rrel_1: rrel_fixed: rrel_scp_const: reflexive_relation;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
+
+	        => nrel_then: ..proc_of_finding_relations_reflexive_propertes_operator5;;
+	        => nrel_else: ..proc_of_finding_relations_reflexive_propertes_operator6;;
 			*);; 
 
-			-> .proc_of_finding_relations_reflexive_propertes_operator5 (*
-			 <- genElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: reflexive_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_reflexive_propertes_operator46;;
+		-> ..proc_of_finding_relations_reflexive_propertes_operator5 
+			(*
+			<- genElStr3;;
+			-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+			-> rrel_3: rrel_fixed: rrel_scp_const: reflexive_relation;;
+
+			=> nrel_goto: ..proc_of_finding_relations_reflexive_propertes_operator46;;
 			*);;
 
-			->.proc_of_finding_relations_reflexive_propertes_operator6 (*
-				<- searchElStr3;;
-				-> rrel_1: rrel_fixed: rrel_scp_const: antireflexive_relation;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
-				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_reflexive_propertes_operator7;;
-	                 	=> nrel_else: .proc_of_finding_relations_reflexive_propertes_operator8;;
+		->..proc_of_finding_relations_reflexive_propertes_operator6 
+			(*
+			<- searchElStr3;;
+			-> rrel_1: rrel_fixed: rrel_scp_const: antireflexive_relation;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
+
+	        => nrel_then: ..proc_of_finding_relations_reflexive_propertes_operator7;;
+	        => nrel_else: ..proc_of_finding_relations_reflexive_propertes_operator8;;
 			*);; 
 
-			-> .proc_of_finding_relations_reflexive_propertes_operator7 (*
-			 <- genElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: antireflexive_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_reflexive_propertes_operator46;;
+		-> ..proc_of_finding_relations_reflexive_propertes_operator7 
+			(*
+			<- genElStr3;;
+			-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+			-> rrel_3: rrel_fixed: rrel_scp_const: antireflexive_relation;;
+
+			=> nrel_goto: ..proc_of_finding_relations_reflexive_propertes_operator46;;
 			*);;
 
-			->.proc_of_finding_relations_reflexive_propertes_operator8 (*
-				<- searchElStr3;;
-				-> rrel_1: rrel_fixed: rrel_scp_const: areflexive_relation;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
-				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_reflexive_propertes_operator9;;
-	                 	=> nrel_else: .proc_of_finding_relations_reflexive_propertes_operator010;;
+		->..proc_of_finding_relations_reflexive_propertes_operator8 
+			(*
+			<- searchElStr3;;
+			-> rrel_1: rrel_fixed: rrel_scp_const: areflexive_relation;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
+
+	        => nrel_then: ..proc_of_finding_relations_reflexive_propertes_operator9;;
+	        => nrel_else: ..proc_of_finding_relations_reflexive_propertes_operator010;;
 			*);; 
 
-			-> .proc_of_finding_relations_reflexive_propertes_operator9 (*
-			 <- genElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: areflexive_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_reflexive_propertes_operator46;;
+		-> ..proc_of_finding_relations_reflexive_propertes_operator9 
+			(*
+			<- genElStr3;;
+			-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+			-> rrel_3: rrel_fixed: rrel_scp_const: areflexive_relation;;
+
+			=> nrel_goto: ..proc_of_finding_relations_reflexive_propertes_operator46;;
 			*);;
 
-			->.proc_of_finding_relations_reflexive_propertes_operator010 (*
-				<- searchElStr5;;
-				-> rrel_1: rrel_assign: rrel_scp_var: _el1;;
-				-> rrel_2: rrel_assign: rrel_const: rrel_common: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_assign: rrel_scp_var: _el2;;
-				-> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc2;;
-				-> rrel_5: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_reflexive_propertes_operator10;;
-	                 	=> nrel_else: .proc_of_finding_relations_reflexive_propertes_operator0000000;;
+		->..proc_of_finding_relations_reflexive_propertes_operator010 
+			(*
+			<- searchElStr5;;
+			-> rrel_1: rrel_assign: rrel_scp_var: _el1;;
+			-> rrel_2: rrel_assign: rrel_const: rrel_common: rrel_scp_var: _arc1;;
+			-> rrel_3: rrel_assign: rrel_scp_var: _el2;;
+			-> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc2;;
+			-> rrel_5: rrel_fixed: rrel_scp_var: _A;;
+
+	        => nrel_then: ..proc_of_finding_relations_reflexive_propertes_operator10;;
+	        => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator_return;;
 			*);; 
 
-			-> .proc_of_finding_relations_reflexive_propertes_operator0000000 (*
-			 <- genElStr3;;
-			 	-> rrel_1: rrel_assign: rrel_scp_var: _answer;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: [Данный элемент не является отношением.];;
 
-			  => nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator_return;;
-			*);;
+		->..proc_of_finding_relations_reflexive_propertes_operator10 
+			(*
+			<- searchSetStr5;;
+			-> rrel_1: rrel_assign: rrel_scp_var: _element1;;
+			-> rrel_2: rrel_assign: rrel_scp_var: _arc;;
+			-> rrel_3: rrel_assign: rrel_scp_var: _element2;;
+			-> rrel_4: rrel_assign: rrel_scp_var: _arc1;;
+			-> rrel_5: rrel_fixed: rrel_scp_var: _A;;
 
-			->.proc_of_finding_relations_reflexive_propertes_operator10 (*
-				<- searchSetStr5;;
-				-> rrel_1: rrel_assign: rrel_scp_var: _element1;;
-				-> rrel_2: rrel_assign: rrel_scp_var: _arc;;
-				-> rrel_3: rrel_assign: rrel_scp_var: _element2;;
-				-> rrel_4: rrel_assign: rrel_scp_var: _arc1;;
-				-> rrel_5: rrel_fixed: rrel_scp_var: _A;;
+		  	-> rrel_set_1: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _not_checkedA;;		  	
+		  	-> rrel_set_3: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _not_checkedA;;
 
-		  		-> rrel_set_1: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _not_checkedA;;		  	
-		  		-> rrel_set_3: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _not_checkedA;;
-
-	             => nrel_then: .proc_of_finding_relations_reflexive_propertes_operator111;;
-	             => nrel_else: .proc_of_finding_relations_reflexive_propertes_operator46;;
+	        => nrel_then: ..proc_of_finding_relations_reflexive_propertes_operator111;;
+	        => nrel_else: ..proc_of_finding_relations_reflexive_propertes_operator46;;
 			*);; 
 
-	    	-> .proc_of_finding_relations_reflexive_propertes_operator111 (*
-				<- genEl;;
-				-> rrel_1: rrel_assign: rrel_const: rrel_node: rrel_scp_var: _midresult;;
-				=> nrel_goto: .proc_of_finding_relations_reflexive_propertes_operator11;;
+
+	    -> ..proc_of_finding_relations_reflexive_propertes_operator111 
+	    	(*
+			<- genEl;;
+			-> rrel_1: rrel_assign: rrel_const: rrel_node: rrel_scp_var: _midresult;;
+			
+			=> nrel_goto: ..proc_of_finding_relations_reflexive_propertes_operator11;;
 			*);;
 			
-			-> .proc_of_finding_relations_reflexive_propertes_operator11 (*
-				<- searchElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_var: _not_checkedA;;
-				-> rrel_2: rrel_assign: rrel_scp_var: _arc_for_delA;;
-				-> rrel_3: rrel_assign: rrel_scp_var: _elem;;
 
-	            => nrel_then: .proc_of_finding_relations_reflexive_propertes_operator012;;
-	            => nrel_else: .proc_of_finding_relations_reflexive_propertes_operator15;;
+		-> ..proc_of_finding_relations_reflexive_propertes_operator11 
+			(*
+			<- searchElStr3;;
+			-> rrel_1: rrel_fixed: rrel_scp_var: _not_checkedA;;
+			-> rrel_2: rrel_assign: rrel_scp_var: _arc_for_delA;;
+			-> rrel_3: rrel_assign: rrel_scp_var: _elem;;
+
+	        => nrel_then: ..proc_of_finding_relations_reflexive_propertes_operator012;;
+	        => nrel_else: ..proc_of_finding_relations_reflexive_propertes_operator15;;
 			*);;
 
-        -> .proc_of_finding_relations_reflexive_propertes_operator012(*
+
+        -> ..proc_of_finding_relations_reflexive_propertes_operator012
+        	(*
 			<- eraseEl;;
 			-> rrel_1: rrel_fixed: rrel_erase: rrel_scp_var: _arc_for_delA;;
 
-					=> nrel_goto: .proc_of_finding_relations_reflexive_propertes_operator12;;
-					*);;
+			=> nrel_goto: ..proc_of_finding_relations_reflexive_propertes_operator12;;
+			*);;
 
-			->.proc_of_finding_relations_reflexive_propertes_operator12 (*
-				<- searchElStr5;;
-				-> rrel_1: rrel_fixed: rrel_scp_var: _elem;;
-				-> rrel_2: rrel_assign: rrel_scp_var: _arcA;;
-				-> rrel_3: rrel_fixed: rrel_scp_var: _elem;;
-				-> rrel_4: rrel_assign: rrel_scp_var: _arcA;;
-				-> rrel_5: rrel_fixed: rrel_scp_var: _A;;
 
-	            => nrel_then: .proc_of_finding_relations_reflexive_propertes_operator13;;
-	            => nrel_else: .proc_of_finding_relations_reflexive_propertes_operator14;;
+		->..proc_of_finding_relations_reflexive_propertes_operator12 
+			(*
+			<- searchElStr5;;
+			-> rrel_1: rrel_fixed: rrel_scp_var: _elem;;
+			-> rrel_2: rrel_assign: rrel_scp_var: _arcA;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _elem;;
+			-> rrel_4: rrel_assign: rrel_scp_var: _arcA;;
+			-> rrel_5: rrel_fixed: rrel_scp_var: _A;;
+
+	        => nrel_then: ..proc_of_finding_relations_reflexive_propertes_operator13;;
+            => nrel_else: ..proc_of_finding_relations_reflexive_propertes_operator14;;
 			*);; 
 
-			-> .proc_of_finding_relations_reflexive_propertes_operator13 (*
-			 <- genElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_var: _midresult;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: reflexive_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_reflexive_propertes_operator11;;
+		-> ..proc_of_finding_relations_reflexive_propertes_operator13 
+			(*
+			<- genElStr3;;
+			-> rrel_1: rrel_fixed: rrel_scp_var: _midresult;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+			-> rrel_3: rrel_fixed: rrel_scp_const: reflexive_relation;;
+
+			=> nrel_goto: ..proc_of_finding_relations_reflexive_propertes_operator11;;
 			*);;
 
-			-> .proc_of_finding_relations_reflexive_propertes_operator14 (*
-			 <- genElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_var: _midresult;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: antireflexive_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_reflexive_propertes_operator11;;
-			*);;
-			
-			-> .proc_of_finding_relations_reflexive_propertes_operator15 (*
-				<- searchElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_var: _midresult;;
-				-> rrel_2: rrel_assign: rrel_scp_var: _arc;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: reflexive_relation;;
+		-> ..proc_of_finding_relations_reflexive_propertes_operator14 
+			(*
+			<- genElStr3;;
+			-> rrel_1: rrel_fixed: rrel_scp_var: _midresult;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+			-> rrel_3: rrel_fixed: rrel_scp_const: antireflexive_relation;;
 
-	             => nrel_then: .proc_of_finding_relations_reflexive_propertes_operator16;;
-	             => nrel_else: .proc_of_finding_relations_reflexive_propertes_operator18;;
+			=> nrel_goto: ..proc_of_finding_relations_reflexive_propertes_operator11;;
 			*);;
 			
-			-> .proc_of_finding_relations_reflexive_propertes_operator16 (*
-				<- searchElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_var: _midresult;;
-				-> rrel_2: rrel_assign: rrel_scp_var: _arc;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: antireflexive_relation;;
 
-	             => nrel_then: .proc_of_finding_relations_reflexive_propertes_operator17;;
-	             => nrel_else: .proc_of_finding_relations_reflexive_propertes_operator20;;
-			*);;
+		-> ..proc_of_finding_relations_reflexive_propertes_operator15 
+			(*
+			<- searchElStr3;;
+			-> rrel_1: rrel_fixed: rrel_scp_var: _midresult;;
+			-> rrel_2: rrel_assign: rrel_scp_var: _arc;;
+			-> rrel_3: rrel_fixed: rrel_scp_const: reflexive_relation;;
 
-			-> .proc_of_finding_relations_reflexive_propertes_operator17 (*
-			 <- genElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: areflexive_relation;;
-
-			  => nrel_goto: .proc_of_finding_relations_reflexive_propertes_operator017;;
-			*);;
-
-			-> .proc_of_finding_relations_reflexive_propertes_operator017 (*
-			 <- genElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_const: areflexive_relation;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
-
-			  => nrel_goto: .proc_of_finding_relations_reflexive_propertes_operator46;;
+	        => nrel_then: ..proc_of_finding_relations_reflexive_propertes_operator16;;
+	        => nrel_else: ..proc_of_finding_relations_reflexive_propertes_operator18;;
 			*);;
 			
-			-> .proc_of_finding_relations_reflexive_propertes_operator18 (*
-				<- searchElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_var: _midresult;;
-				-> rrel_2: rrel_assign: rrel_scp_var: _arc;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: antireflexive_relation;;
 
-	             => nrel_then: .proc_of_finding_relations_reflexive_propertes_operator19;;
-	             => nrel_else: .proc_of_finding_relations_reflexive_propertes_operator46;;
+		-> ..proc_of_finding_relations_reflexive_propertes_operator16 
+			(*
+			<- searchElStr3;;
+			-> rrel_1: rrel_fixed: rrel_scp_var: _midresult;;
+			-> rrel_2: rrel_assign: rrel_scp_var: _arc;;
+			-> rrel_3: rrel_fixed: rrel_scp_const: antireflexive_relation;;
+
+	        => nrel_then: ..proc_of_finding_relations_reflexive_propertes_operator17;;
+	        => nrel_else: ..proc_of_finding_relations_reflexive_propertes_operator20;;
 			*);;
 
-			-> .proc_of_finding_relations_reflexive_propertes_operator19 (*
-			 <- genElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: antireflexive_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_reflexive_propertes_operator019;;
+		-> ..proc_of_finding_relations_reflexive_propertes_operator17 
+			(*
+			<- genElStr3;;
+			-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+			-> rrel_3: rrel_fixed: rrel_scp_const: areflexive_relation;;
+
+			=> nrel_goto: ..proc_of_finding_relations_reflexive_propertes_operator017;;
 			*);;
 
-			-> .proc_of_finding_relations_reflexive_propertes_operator019 (*
-			 <- genElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_const: antireflexive_relation;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-			  => nrel_goto: .proc_of_finding_relations_reflexive_propertes_operator46;;
+		-> ..proc_of_finding_relations_reflexive_propertes_operator017 
+			(*
+			<- genElStr3;;
+			-> rrel_1: rrel_fixed: rrel_scp_const: areflexive_relation;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
+
+			=> nrel_goto: ..proc_of_finding_relations_reflexive_propertes_operator46;;
+			*);;
+			
+
+		-> ..proc_of_finding_relations_reflexive_propertes_operator18 
+			(*
+			<- searchElStr3;;
+			-> rrel_1: rrel_fixed: rrel_scp_var: _midresult;;
+			-> rrel_2: rrel_assign: rrel_scp_var: _arc;;
+			-> rrel_3: rrel_fixed: rrel_scp_const: antireflexive_relation;;
+
+	        => nrel_then: ..proc_of_finding_relations_reflexive_propertes_operator19;;
+	        => nrel_else: ..proc_of_finding_relations_reflexive_propertes_operator46;;
 			*);;
 
-			-> .proc_of_finding_relations_reflexive_propertes_operator20 (*
-			 <- genElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: reflexive_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_reflexive_propertes_operator020;;
+		-> ..proc_of_finding_relations_reflexive_propertes_operator19 
+			(*
+			<- genElStr3;;
+			-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+			-> rrel_3: rrel_fixed: rrel_scp_const: antireflexive_relation;;
+
+			=> nrel_goto: ..proc_of_finding_relations_reflexive_propertes_operator019;;
 			*);;
 
-			-> .proc_of_finding_relations_reflexive_propertes_operator020 (*
-			 <- genElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_const: reflexive_relation;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-			  => nrel_goto: .proc_of_finding_relations_reflexive_propertes_operator46;;
+		-> ..proc_of_finding_relations_reflexive_propertes_operator019 
+			(*
+			<- genElStr3;;
+			-> rrel_1: rrel_fixed: rrel_scp_const: antireflexive_relation;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
+
+			=> nrel_goto: ..proc_of_finding_relations_reflexive_propertes_operator46;;
 			*);;
 
-			-> .proc_of_finding_relations_reflexive_propertes_operator46 (*
-				<- call;; 
-				-> rrel_1: rrel_fixed: rrel_scp_const:  proc_add_three_elements;;
-				->rrel_2:rrel_fixed:rrel_scp_const: 
-				.proc_of_finding_relations_reflexive_propertes_operator46_params (*
-					-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
-					-> rrel_2: rrel_fixed: rrel_scp_var: _A;;
-					-> rrel_3: rrel_assign: rrel_scp_var: _answer;;
-				*);;
-				-> rrel_3: rrel_assign: rrel_scp_var: _descr;;
-				=>nrel_goto: .proc_of_finding_relations_reflexive_propertes_operator47;;
+
+		-> ..proc_of_finding_relations_reflexive_propertes_operator20 
+		    (*
+			<- genElStr3;;
+			-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+			-> rrel_3: rrel_fixed: rrel_scp_const: reflexive_relation;;
+
+			=> nrel_goto: ..proc_of_finding_relations_reflexive_propertes_operator020;;
 			*);;
 
-			-> .proc_of_finding_relations_reflexive_propertes_operator47 (*
-				<- waitReturn;;
-				-> rrel_1: rrel_fixed: rrel_scp_var: _descr;;
-				=>nrel_goto: .proc_of_finding_relations_reflexive_propertes_operator_return;;
+
+		-> ..proc_of_finding_relations_reflexive_propertes_operator020 
+			(*
+			<- genElStr3;;
+			-> rrel_1: rrel_fixed: rrel_scp_const: reflexive_relation;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
+
+			=> nrel_goto: ..proc_of_finding_relations_reflexive_propertes_operator46;;
 			*);;
 
-			-> .proc_of_finding_relations_reflexive_propertes_operator_return 
+
+		-> ..proc_of_finding_relations_reflexive_propertes_operator46 
+			(*
+			<- call;; 
+			-> rrel_1: rrel_fixed: rrel_scp_const:  proc_add_three_elements;;
+			-> rrel_2:rrel_fixed:rrel_scp_const: ..proc_of_finding_relations_reflexive_propertes_operator46_params 
 				(*
-				<- return;;
+				-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
+				-> rrel_2: rrel_fixed: rrel_scp_var: _A;;
+				-> rrel_3: rrel_assign: rrel_scp_var: _answer;;
+				*);;
+			-> rrel_3: rrel_assign: rrel_scp_var: _descr;;
+
+			=>nrel_goto: ..proc_of_finding_relations_reflexive_propertes_operator47;;
+			*);;
+
+
+		-> ..proc_of_finding_relations_reflexive_propertes_operator47 
+			(*
+			<- waitReturn;;
+			-> rrel_1: rrel_fixed: rrel_scp_var: _descr;;
+
+			=>nrel_goto: ..proc_of_finding_relations_reflexive_propertes_operator_return;;
+			*);;
+
+
+		-> ..proc_of_finding_relations_reflexive_propertes_operator_return 
+			(*
+			<- return;;
 			*);;
 		*);;
 	*);;

--- a/kb_main/agents/agents_operations_on_relations/agent_operations/agent_operations.scsi
+++ b/kb_main/agents/agents_operations_on_relations/agent_operations/agent_operations.scsi
@@ -6,230 +6,227 @@ agent_operations
 
 scp_program -> agent_operations 
 	(*
-	-> rrel_params: .agent_operations_params 
+	-> rrel_params: ..agent_operations_params 
 		(*
 		-> rrel_1: rrel_in: _event;;
 		-> rrel_2: rrel_in: _input_arc;;
 		*);;
 
-	-> rrel_operators: .agent_operations_operator_set 
+	-> rrel_operators: ..agent_operations_operator_set 
 		(*
-		-> rrel_init: .agent_operations_operator1 
+		-> rrel_init: ..agent_operations_operator1 
 			(*
 			<- searchElStr3;;
 			-> rrel_1: rrel_assign: rrel_scp_var: _temp;;
 			-> rrel_2: rrel_fixed: rrel_scp_var: _input_arc;;
 			-> rrel_3: rrel_assign: rrel_scp_var: _quest;;
 
-			=> nrel_goto: .agent_operations_operator2;;
+			=> nrel_goto: ..agent_operations_operator2;;
 			*);;
 
-		-> .agent_operations_operator2 
+
+		-> ..agent_operations_operator2 
 			(*
 			<- searchElStr3;;
 			-> rrel_1: rrel_fixed: rrel_scp_const: question_operations;;
 			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
 			-> rrel_3: rrel_fixed: rrel_scp_var: _quest;;
 
-			=> nrel_then: .agent_operations_operator3;;
-			=> nrel_else: .agent_operations_operator_return;;
+			=> nrel_then: ..agent_operations_operator3;;
+			=> nrel_else: ..agent_operations_operator_return;;
 			*);;
 
-		-> .agent_operations_operator3
+
+		-> ..agent_operations_operator3
 			(*
 			<- searchElStr3;;
 			-> rrel_1: rrel_fixed: rrel_scp_var: _quest;;
 			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
 			-> rrel_3: rrel_assign: rrel_scp_var: _param;;
 
-			=> nrel_then: .agent_operations_operator4;;
-			=> nrel_else: .agent_operations_operator_return;;
+			=> nrel_then: ..agent_operations_operator4;;
+			=> nrel_else: ..agent_operations_operator_return;;
 			*);;
 
-		-> .agent_operations_operator4
+
+		-> ..agent_operations_operator4
 			(*
 		 	<- genEl;;
 		 	-> rrel_1: rrel_assign: rrel_const: rrel_node: rrel_scp_var: _answer;;
 
-		 	=> nrel_goto: .agent_operations_operator4A;;
+		 	=> nrel_goto: ..agent_operations_operator4A;;
 		 	*);;
 
-		-> .agent_operations_operator4A
+
+		-> ..agent_operations_operator4A
 			(*
 			<- searchElStr3;;
-			-> rrel_1: rrel_scp_const: set;;
-			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
+
+		 	-> rrel_1: rrel_fixed: rrel_scp_const: binary_relation;;
+			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
 			-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
 
-			=> nrel_then: .agent_operations_operator4B;;
-			=> nrel_else: .agent_operations_operator5;;
+			=> nrel_then: ..agent_operations_operator5;;	
+			=> nrel_else: ..agent_operations_operator_add_validating_message;;
 			*);;
 
-		-> .agent_operations_operator4B
-			(*
-			<- genElStr3;;
-			-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
-			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
-			-> rrel_3: rrel_scp_const: set;;
-
-			=> nrel_goto: .agent_operations_operator4C;;
-			*);;
-
-		-> .agent_operations_operator4C
-			(*
-			<- genElStr3;;
-			-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
-			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
-			-> rrel_3: rrel_fixed: rrel_scp_var: _arc;;
-
-			=> nrel_goto: .agent_operations_operator_add_param;;
-			*);;
 
 		// если это отношение порядка
-		-> .agent_operations_operator5
+		-> ..agent_operations_operator5
 			(*
 			<- searchElStr3;;
 			-> rrel_1: rrel_scp_const: order_relation;;
 			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
 			-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
 
-			=> nrel_then: .agent_operations_operator6;;
-			=> nrel_else: .agent_operations_operator5A;;
+			=> nrel_then: ..agent_operations_operator6;;
+			=> nrel_else: ..agent_operations_operator5A;;
 			*);;
 
-		-> .agent_operations_operator5A
+
+		-> ..agent_operations_operator5A
 			(*
 			<- searchElStr3;;
 			-> rrel_1: rrel_scp_const: antisymmetric_relation;;
 			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
 			-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
 
-			=> nrel_then: .agent_operations_operator5B;;
-			=> nrel_else: .agent_operations_operator_add_param;;
+			=> nrel_then: ..agent_operations_operator5B;;
+			=> nrel_else: ..agent_operations_operator_add_arc;;
 			*);;
 
-		-> .agent_operations_operator5B
+
+		-> ..agent_operations_operator5B
 			(*
 			<- searchElStr3;;
 			-> rrel_1: rrel_scp_const: transitive_relation;;
 			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
 			-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
 
-			=> nrel_then: .agent_operations_operator6;;
-			=> nrel_else: .agent_operations_operator_add_param;;
+			=> nrel_then: ..agent_operations_operator6;;
+			=> nrel_else: ..agent_operations_operator_add_arc;;
 			*);;
 
 		//===
 		// если отношение нестрогого порядка
-		-> .agent_operations_operator6
+		-> ..agent_operations_operator6
 			(*
 			<- searchElStr3;;
 			-> rrel_1: rrel_scp_const: non_strict_order_relation;;
 			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
 			-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
 
-			=> nrel_then: .agent_operations_operator6A;;
-			=> nrel_else: .agent_operations_operator6C;;
+			=> nrel_then: ..agent_operations_operator6A;;
+			=> nrel_else: ..agent_operations_operator6C;;
 			*);;
 
-		-> .agent_operations_operator6A
+
+		-> ..agent_operations_operator6A
 			(*
 		 	<- genElStr3;;
 		 	-> rrel_1: rrel_scp_const: non_strict_order_relation;;
 			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
 			-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
 
-            => nrel_goto: .agent_operations_operator6B;;
+            => nrel_goto: ..agent_operations_operator6B;;
 		 	*);;
 
-		-> .agent_operations_operator6B
+
+		-> ..agent_operations_operator6B
 			(*
 		 	<- genElStr3;;
 		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
 		 	-> rrel_3: rrel_scp_const: non_strict_order_relation;;
 
-            => nrel_goto: .agent_operations_operator_add_arc;;
+            => nrel_goto: ..agent_operations_operator_add_arc;;
 		 	*);;
 
+
 		// проверка является ли отношение рефлексивным
-		-> .agent_operations_operator6C
+		-> ..agent_operations_operator6C
 			(*
 			<- searchElStr3;;
 			-> rrel_1: rrel_scp_const: reflexive_relation;;
 			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
 			-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
 
-			=> nrel_then: .agent_operations_operator6A;;
-			=> nrel_else: .agent_operations_operator7;;
+			=> nrel_then: ..agent_operations_operator6A;;
+			=> nrel_else: ..agent_operations_operator7;;
 			*);;
 
 		//===
 		// если отношение строгого порядка
-		-> .agent_operations_operator7
+		-> ..agent_operations_operator7
 			(*
 			<- searchElStr3;;
 			-> rrel_1: rrel_scp_const: strict_order_relation;;
 			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
 			-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
 
-			=> nrel_then: .agent_operations_operator7A;;
-			=> nrel_else: .agent_operations_operator7C;;
+			=> nrel_then: ..agent_operations_operator7A;;
+			=> nrel_else: ..agent_operations_operator7C;;
 			*);;
 
-		-> .agent_operations_operator7A
+
+		-> ..agent_operations_operator7A
 			(*
 		 	<- genElStr3;;
 		 	-> rrel_1: rrel_scp_const: strict_order_relation;;
 			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
 			-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
 
-            => nrel_goto: .agent_operations_operator7B;;
+            => nrel_goto: ..agent_operations_operator7B;;
 		 	*);;
 
-		-> .agent_operations_operator7B
+
+		-> ..agent_operations_operator7B
 			(*
 			<- genElStr3;;
 			-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
 		 	-> rrel_3: rrel_scp_const: strict_order_relation;;
 
-			=> nrel_goto: .agent_operations_operator_add_arc;;
+			=> nrel_goto: ..agent_operations_operator_add_arc;;
 			*);;
 
-		// проверка является ли отношение антирефлексивным
-		-> .agent_operations_operator7C
+
+		//проверка является ли отношение антирефлексивным
+		-> ..agent_operations_operator7C
 			(*
 			<- searchElStr3;;
 			-> rrel_1: rrel_scp_const: antireflexive_relation;;
 			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
 			-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
 
-			=> nrel_then: .agent_operations_operator7A;;
-			=> nrel_else: .agent_operations_operator_add_param;;
+			=> nrel_then: ..agent_operations_operator7A;;
+			=> nrel_else: ..agent_operations_operator_add_param;;
 			*);;
 
-		-> .agent_operations_operator_add_arc
+
+		-> ..agent_operations_operator_add_arc
 			(*
 		 	<- genElStr3;;
 		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
 		 	-> rrel_3: rrel_fixed: rrel_scp_var: _arc;;
 
-            => nrel_goto: .agent_operations_operator_add_param;;
+            => nrel_goto: ..agent_operations_operator_add_param;;
 		 	*);;
 
-		-> .agent_operations_operator_add_param
+
+		-> ..agent_operations_operator_add_param
 			(*
 		 	<- genElStr3;;
 		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
 		 	-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
 
-            => nrel_goto: .agent_operations_operator_gen_answer;;
+            => nrel_goto: ..agent_operations_operator_gen_answer;;
 		 	*);;
 
-		-> .agent_operations_operator_gen_answer
+
+		-> ..agent_operations_operator_gen_answer
 			(*
 		  	<- genElStr5;;
 		  	-> rrel_1: rrel_fixed: rrel_scp_var: _quest;;
@@ -238,10 +235,44 @@ scp_program -> agent_operations
 		  	-> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc2;;
 		  	-> rrel_5: rrel_fixed: rrel_scp_const: nrel_answer;;
 
-		  	=> nrel_goto: .agent_operations_operator_return;;
-			*);;    
+		  	=> nrel_goto: ..agent_operations_operator_succesfull;;
+			*);;  
 
-		 -> .agent_operations_operator_return 
+
+		-> ..agent_operations_operator_succesfull
+			(*
+			<- genElStr3;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_const: question_finished_successfully;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _quest;;
+
+			=> nrel_goto: ..agent_operations_operator_return;;
+			*);;  
+
+
+		-> ..agent_operations_operator_add_validating_message
+			(*
+            <- printNl;;
+            -> rrel_1: rrel_scp_const: [Wrong parametr! It must be binary relation.];;
+
+		  	=> nrel_goto: ..agent_operations_operator_gen_unsucces;;
+			*);;
+
+
+		-> ..agent_operations_operator_gen_unsucces
+			(*
+			<- genElStr3;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_const: question_finished_unsuccessfully;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _quest;;
+
+			=> nrel_goto: ..agent_operations_operator_return;; 
+			*);;
+
+
+		 -> ..agent_operations_operator_return 
 			(*
 		  	<- return;;
 			*);;


### PR DESCRIPTION
Коммит 'New algorithm':
Агент (agent_checking_whether_the_agent_is_a_transitive_relation) не работал не при каких тестах, поэтому было принято решение переписать полностью. Суть нового алгоритма заключается сначала в проверке входного параметра на принадлежность классу бинарных отношений, затем проверки на принадлежность классу транзитивное отношение, а затем поиск конструкций как на картинке New algorithm (прикреплена в trello), где _node_prev это test_node_one, _node это test_node_two, _node_next это test_node_three, и если подобные конструкции найдены, то входной параметр считается транзитивным отношением иначе антитранзитивным, а в случае если входное отношение не является бинарным отношением, то будет выведено сообщение об ошибке в консоль. Вывод ошибки через proc_of_adding_validating_message не был реализован по причине ошибки при запуске этой программы.
Коммит 'Delete printNl': 
Агент (agent_definitional_domain) работает. Были удалены только ненужные операторы вывода сообщений в консоль о том, что за программа начала работать, какой был найден домен.
Коммит 'Add test for binary relation and delete printNl': 
Агент (agent_of_finding_relations_reflexive_propertes) работает. Были удалены только ненужные операторы вывода сообщений в консоль о том, что за программа начала работать. Удалён оператор создания конструкции (.proc_of_finding_relations_reflexive_propertes_operator0000000) так как он не имеет смысла из-за невозможности вывода в localhost подобных конструкций. Добавлена проверка на принадлежность классу бинарных отношений.
Коммит 'Add test for binary relation': 
Агент (agent_operations) работает. Добавлена проверка на принадлежность классу бинарных отношений.